### PR TITLE
Update de rotas de Observação de Ação em PP

### DIFF
--- a/Back/app/api/pontoPresenca.js
+++ b/Back/app/api/pontoPresenca.js
@@ -524,30 +524,50 @@ module.exports = function(app){
         connection.end();
     };
 
+    //Lista as Observações de Ação de vários Ponto de presença.
+    api.listaMultObsAcaoId = (req, res) => {
+        const connection = app.conexao.conexaoBD();
+        const pontoPresencaDAO = new app.infra.PontoPresencaDAO(connection);
+        const { cod_gesac } = req.query;
+
+        pontoPresencaDAO.listarMultObsAcaoId(cod_gesac, (erro, resultado) => {
+            erro ? (console.log(erro), res.status(500).send(app.api.erroPadrao())) : res.status(200).json(resultado);
+        });
+
+        connection.end();
+    };
+
     //Apaga uma Observação de Ação de um Ponto de Presença.
     api.apagaObsAcao = (req, res) => {
         const knex = app.conexao.conexaoBDKnex();
-        const { cod_gesac, cod_obs } = req.body;
+        const { cod_gesac, cod_obs } = req.query;
         let gesac_obs_acao = [];
 
-        if(Array.isArray(cod_gesac)){
-            for(let i=0; i<cod_gesac.length; i++){
-                gesac_obs_acao[i] = [cod_gesac[i], cod_obs];
-            }
-        } else {
-            gesac_obs_acao[0] = [cod_gesac, cod_obs];
-        }
+        if(cod_gesac){
+            const cods_gesac = cod_gesac.split(",");
 
-        knex('gesac_obs_acao').whereIn(['cod_gesac', 'cod_obs'], gesac_obs_acao).delete()
-            .then(resultado => {
-                knex.destroy();
-                res.status(200).end();
-            })
-            .catch(erro => {
-                console.log(erro);
-                knex.destroy();
-                res.status(500).send(app.api.erroPadrao());
-            });
+            if(Array.isArray(cods_gesac)){
+                for(let i=0; i<cods_gesac.length; i++){
+                    gesac_obs_acao[i] = [cods_gesac[i], cod_obs];
+                }
+            } else {
+                gesac_obs_acao[0] = [cod_gesac, cod_obs];
+            }
+
+            knex('gesac_obs_acao').whereIn(['cod_gesac', 'cod_obs'], gesac_obs_acao).delete()
+                .then(resultado => {
+                    knex.destroy();
+                    res.status(200).end();
+                })
+                .catch(erro => {
+                    console.log(erro);
+                    knex.destroy();
+                    res.status(500).send(app.api.erroPadrao());
+                });   
+
+        } else {
+            res.status(400).send(app.api.erroPadrao());
+        }
     }
     
     return api;    

--- a/Back/app/infra/PontoPresencaDAO.js
+++ b/Back/app/infra/PontoPresencaDAO.js
@@ -53,7 +53,7 @@ PontoPresencaDAO.prototype.listarSolicitacaoId = function(data_sistema, tipo_sol
 
  //Lista os tipos de Solicitações de um Status de um Ponto de Presença.
 PontoPresencaDAO.prototype.listarTipoSolicitacaoStatus = function(cod_status, callback){
-	this._connection.query(`SELECT * FROM permissao INNER JOIN tipo_solicitacao ON permissao.tipo_solicitacao = tipo_solicitacao.tipo_solicitacao WHERE permissao.cod_status = ${cod_status} and permissao.tipo_permissao = 1`, callback);
+	this._connection.query(`SELECT * FROM permissao INNER JOIN tipo_solicitacao ON permissao.tipo_solicitacao = tipo_solicitacao.tipo_solicitacao WHERE permissao.cod_status = ${cod_status} and permissao.tipo_permissao <> 2`, callback);
 }
 
  //Lista os tipos de Solicitações de um Status de um Ponto de Presença.
@@ -109,6 +109,11 @@ PontoPresencaDAO.prototype.listarHistoricoPontoPresenca = function(cod_gesac, ca
 //Lista as Observações de Ação de um Ponto de presença.
 PontoPresencaDAO.prototype.listarObsAcaoId = function(cod_gesac, callback){
 	this._connection.query(`SELECT obs_acao.* FROM obs_acao INNER JOIN gesac_obs_acao ON obs_acao.cod_obs = gesac_obs_acao.cod_obs INNER JOIN gesac ON gesac_obs_acao.cod_gesac = gesac.cod_gesac WHERE gesac.cod_gesac = ${cod_gesac}`, callback);
+}
+
+//Lista as Observações de Ação de vários Ponto de presença.
+PontoPresencaDAO.prototype.listarMultObsAcaoId = function(cod_gesac, callback){
+	this._connection.query(`SELECT gesac.cod_gesac, GROUP_CONCAT(obs_acao.cod_obs) AS 'cod_obs' FROM gesac LEFT JOIN gesac_obs_acao ON gesac.cod_gesac = gesac_obs_acao.cod_gesac LEFT JOIN obs_acao ON gesac_obs_acao.cod_obs = obs_acao.cod_obs WHERE gesac.cod_gesac IN (${cod_gesac}) GROUP BY cod_gesac`, callback);
 }
 
 module.exports = () => {

--- a/Back/app/routes/routes.js
+++ b/Back/app/routes/routes.js
@@ -91,6 +91,9 @@ module.exports = function(app){
         .post(pontoPresenca.salvaObservacao)
         .delete(pontoPresenca.apagaObsAcao);
 
+    app.route('/gesac/multObsAcao')
+        .get(pontoPresenca.listaMultObsAcaoId);
+
     app.route('/gesac/obsAcao/:cod_gesac')
         .get(pontoPresenca.listaObsAcaoId);
     


### PR DESCRIPTION
Rotas de Observação de Ação:
Nova rota utilizada para lista as observações de ação de vários gesac ao mesmo tempo. Esta rota recebe como parâmetro um array com os códigos gesac a serem procurados, e retorna os mesmos códigos juntamente com os códigos das suas observações.

A rota que apaga uma observação de ação de um ou mais gesac foi atualizada para receber as informações através de parâmetros passados pela rota, que anteriormente acontecia através do corpo da requisição.