### PR TITLE
Implementação latitude e longitude

### DIFF
--- a/Front/src/app/pipes/directives/latitude-mask.directive.ts
+++ b/Front/src/app/pipes/directives/latitude-mask.directive.ts
@@ -1,0 +1,99 @@
+import { Directive, HostListener, ElementRef, Output, EventEmitter } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+
+@Directive({
+  selector: '[appLatitudeMask]',
+  providers: [{
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: LatitudeMaskDirective,
+    multi: true
+  }]
+})
+export class LatitudeMaskDirective implements ControlValueAccessor {
+
+  onTouched: any;
+  onChange: any;
+  @Output() ngModelChange: EventEmitter<any> = new EventEmitter();
+
+  constructor(private elementRef: ElementRef) {
+  }
+
+  writeValue(value: any): void {
+    if (value) {
+      const valor = this.formatar(value);
+      this.elementRef.nativeElement.value = valor;
+      this.ngModelChange.emit(valor);
+    }
+  }
+
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+
+  @HostListener('input', ['$event'])
+  onInput($event: any) {
+    const valor = $event.target.value.replace( /\s/g, '').replace(/\,/g, '.');
+    if (valor.length <= 10) {
+
+    // retorna caso pressionado backspace
+    if ($event.keyCode === 8) {
+      this.onChange(valor);
+      return;
+    }
+
+    $event.target.value = this.formatar(valor);
+    this.ngModelChange.emit($event.target.value);
+    }
+  }
+
+  @HostListener('blur', ['$event'])
+  onBlur($event: any) {
+    const valor = $event.target.value.replace( /\s/g, '').replace(/\,/g, '.');
+    $event.target.value = this.formatar(valor);
+    this.ngModelChange.emit($event.target.value);
+  }
+
+  formatar(valor) {
+    let newValor = '';
+    for (let i = 0; i < valor.length; i++) {
+      if (i === 0 && (valor[i] === '+' || valor[i] === '-')) {
+        newValor = valor[i];
+      } else if (i > 0) {
+        if (i === 1 && isNaN(valor[i])) {
+          newValor = '';
+          break;
+        } else {
+          if (!isNaN(valor[i]) && (i !== 0 && i !== 2 && i !== 3)) {
+            if (((i <= 9) && (newValor[2] !== '.')) && !isNaN(valor[i])) {
+              newValor += valor[i];
+            } else if ((i <= 8) && !isNaN(valor[i])) {
+              newValor += valor[i];
+            } else {
+              break;
+            }
+          } else if (i === 2 && (!isNaN(valor[i]) || valor[i] === '.')) {
+            newValor += valor[i];
+          } else if (i === 3 && (!isNaN(valor[i]) || valor[i] === '.')) {
+            if (!isNaN(valor[i - 1]) === !isNaN(valor[i])) {
+              if (!isNaN(valor[i])) {
+                newValor += `.${valor[i]}`;
+              } else {
+                break;
+              }
+            } else {
+              newValor += valor[i];
+            }
+          }
+        }
+      } else {
+        break;
+      }
+    }
+    return newValor;
+  }
+
+}

--- a/Front/src/app/pipes/directives/longitude-mask.directive.ts
+++ b/Front/src/app/pipes/directives/longitude-mask.directive.ts
@@ -1,0 +1,124 @@
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+import { Directive, HostListener, ElementRef, Output, EventEmitter } from '@angular/core';
+
+@Directive({
+  selector: '[appLongitudeMask]',
+  providers: [{
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: LongitudeMaskDirective,
+    multi: true
+  }]
+})
+export class LongitudeMaskDirective  implements ControlValueAccessor {
+  onTouched: any;
+  onChange: any;
+  @Output() ngModelChange: EventEmitter<any> = new EventEmitter();
+
+  constructor(private elementRef: ElementRef) {
+  }
+
+  writeValue(value: any): void {
+    if (value) {
+      const valor = this.formatar(value);
+      this.elementRef.nativeElement.value = valor;
+      this.ngModelChange.emit(valor);
+    }
+  }
+
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+  @HostListener('input', ['$event'])
+  onInput($event: any) {
+    const valor = $event.target.value.replace( /\s/g, '').replace(/\,/g, '.');
+    if (valor.length <= 11) {
+
+    // retorna caso pressionado backspace
+    if ($event.keyCode === 8) {
+      this.onChange(valor);
+      return;
+    }
+
+    $event.target.value = this.formatar(valor);
+    this.ngModelChange.emit($event.target.value);
+    }
+  }
+
+  @HostListener('blur', ['$event'])
+  onBlur($event: any) {
+    const valor = $event.target.value.replace( /\s/g, '').replace(/\,/g, '.');
+    $event.target.value = this.formatar(valor);
+    this.ngModelChange.emit($event.target.value);
+  }
+
+  formatar(valor) {
+    let newValor = '';
+    for (let i = 0; i < valor.length; i++) {
+      if (i === 0 && valor[i] === '-') {
+        newValor = valor[i];
+      } else if (i > 0) {
+        if (i === 1 && isNaN(valor[i])) {
+          newValor = '';
+          break;
+        } else {
+        if ((i !== 0 && i !== 2 && i !== 3 && i !== 4) && !isNaN(valor[i])) {
+          if ((i > 8) && valor[2] === '.') {
+            break;
+          }
+          if ((i > 9) && valor[3] === '.') {
+            break;
+          }
+          if ((i > 10) && valor[4] === '.') {
+            break;
+          } else {
+            newValor += valor[i];
+          }
+        } else if (i === 2 && (!isNaN(valor[i]) || valor[i] === '.')) {
+          newValor += valor[i];
+        } else if (i === 3 && (!isNaN(valor[i]) || valor[i] === '.')) {
+          if (!isNaN(valor[i - 1]) === !isNaN(valor[i])) {
+            if (!isNaN(valor[i])) {
+              newValor += valor[i];
+            } else {
+              break;
+            }
+          } else {
+            newValor += valor[i];
+          }
+        } else if (i === 4 && (!isNaN(valor[i]) || valor[i] === '.')) {
+          if ((!isNaN(valor[i - 1]) === !isNaN(valor[i])) && (!isNaN(valor[i - 2]) === !isNaN(valor[i]))) {
+            if (!isNaN(valor[i])) {
+              newValor += `.${valor[i]}`;
+            } else {
+              break;
+            }
+          } else {
+            if (isNaN(valor[i - 2]) && isNaN(valor[i])) {
+              break;
+            } else if (isNaN(valor[i - 1]) && isNaN(valor[i])) {
+              break;
+            } else {
+              newValor += valor[i];
+            }
+          }
+        } else {
+          break;
+        }
+      }
+      } else {
+        if (!isNaN(valor[i])) {
+          newValor += `-${valor[i]}`;
+          break;
+        } else {
+          break;
+        }
+      }
+    }
+    return newValor;
+  }
+
+}

--- a/Front/src/app/pipes/shared.module.ts
+++ b/Front/src/app/pipes/shared.module.ts
@@ -15,6 +15,8 @@ import { FilterPagadoraPipe } from './filter-pagadora.pipe';
 import { FilterHistoricoAcoesPipe } from './filter-historico-acoes.pipe';
 import { FilterRepresentantePipe } from './filter-representantes.pipe';
 import { FilterContatoPipe } from './filter-contato.pipe';
+import { LatitudeMaskDirective } from './directives/latitude-mask.directive';
+import { LongitudeMaskDirective } from './directives/longitude-mask.directive';
 
 
 @NgModule({
@@ -38,7 +40,9 @@ import { FilterContatoPipe } from './filter-contato.pipe';
     FilterPagadoraPipe,
     FilterHistoricoAcoesPipe,
     FilterContatoPipe,
-    FilterRepresentantePipe
+    FilterRepresentantePipe,
+    LatitudeMaskDirective,
+    LongitudeMaskDirective
   ],
   exports: [
     CommonModule,
@@ -58,7 +62,9 @@ import { FilterContatoPipe } from './filter-contato.pipe';
     FilterPagadoraPipe,
     FilterHistoricoAcoesPipe,
     FilterContatoPipe,
-    FilterRepresentantePipe
+    FilterRepresentantePipe,
+    LatitudeMaskDirective,
+    LongitudeMaskDirective
   ]
 })
 export class SharedModule {}

--- a/Front/src/app/ponto-presenca/ponto-presenca-add-edit/ponto-presenca-add-edit.component.html
+++ b/Front/src/app/ponto-presenca/ponto-presenca-add-edit/ponto-presenca-add-edit.component.html
@@ -191,38 +191,32 @@
           </div>
           <div class="ui segment" *ngIf="novoEndereco === true">
             <form class="ui form error" #fAddEndereco="ngForm" (ngSubmit)="salvarEndereco(fAddEndereco)">
-              <div class="field">
-                <div class="fields">
-
-                  <div class="fourteen wide field" [ngClass]="{'error':  endereco.invalid && fAddEndereco.submitted ||  endereco.invalid && endereco.dirty}">
-                    <label for="endereco">Endereço</label>
-                    <input id="endereco" type="text" class="validate" name="endereco" #endereco="ngModel" [(ngModel)]="enderecoPontPre.endereco"
-                      required>
-                    <div class="invalid-feedback" [ngClass]="{'active':  endereco.invalid && fAddEndereco.submitted ||  endereco.invalid && endereco.dirty}">
-                      Endereço obrigatório!
-                    </div>
-                  </div>
-
-                  <div class="two wide field">
-                    <label for="numero">Nº</label>
-                    <input id="numero" type="tel" class="validate" name="numero" [(ngModel)]="enderecoPontPre.numero">
-                  </div>
-
-                  <div class="four wide field">
-                    <label for="bairro">Bairro</label>
-                    <input id="bairro" type="text" class="validate" name="bairro" [(ngModel)]="enderecoPontPre.bairro">
-                  </div>
-
-                  <div class="twelve wide field">
-                    <label for="complemento">Complemento</label>
-                    <input id="complemento" type="text" class="validate" name="complemento" [(ngModel)]="enderecoPontPre.complemento">
+              <div class="fields">
+                <div class="fourteen wide field" [ngClass]="{'error':  endereco.invalid && fAddEndereco.submitted ||  endereco.invalid && endereco.dirty}">
+                  <label for="endereco">Endereço</label>
+                  <input id="endereco" type="text" class="validate" name="endereco" #endereco="ngModel" [(ngModel)]="enderecoPontPre.endereco"
+                    required>
+                  <div class="invalid-feedback" [ngClass]="{'active':  endereco.invalid && fAddEndereco.submitted ||  endereco.invalid && endereco.dirty}">
+                    Endereço obrigatório!
                   </div>
                 </div>
+                <div class="two wide field">
+                  <label for="numero">Nº</label>
+                  <input id="numero" type="tel" class="validate" name="numero" [(ngModel)]="enderecoPontPre.numero">
+                </div>
+                <div class="four wide field">
+                  <label for="bairro">Bairro</label>
+                  <input id="bairro" type="text" class="validate" name="bairro" [(ngModel)]="enderecoPontPre.bairro">
+                </div>
 
+                <div class="twelve wide field">
+                  <label for="complemento">Complemento</label>
+                  <input id="complemento" type="text" class="validate" name="complemento" [(ngModel)]="enderecoPontPre.complemento">
+                </div>
               </div>
 
-              <div class="ui grid ">
-                <div class="three wide column field" [ngClass]="{'error': cep.invalid && fAddEndereco.submitted || cep.invalid && cep.dirty}">
+              <div class="fields">
+                <div class="two wide field" [ngClass]="{'error': cep.invalid && fAddEndereco.submitted || cep.invalid && cep.dirty}">
                   <label for="cep">CEP</label>
 
                   <input id="cep" type="text" mask="00.000-000" class="validate" name="cep" #cep='ngModel' [(ngModel)]="enderecoPontPre.cep"
@@ -232,7 +226,7 @@
                   </div>
                 </div>
 
-                <div class="three wide column field" [ngClass]="{'error': area.invalid && fAddEndereco.submitted ||  area.invalid && area.dirty}">
+                <div class="two wide field" [ngClass]="{'error': area.invalid && fAddEndereco.submitted ||  area.invalid && area.dirty}">
                   <label>Área</label>
                   <select class="ui fluid dropdown" name="area" #area='ngModel' [(ngModel)]="enderecoPontPre.area" required>
 
@@ -245,22 +239,91 @@
                   </div>
                 </div>
 
-
-                <div class="five wide column">
-                  <label for="latitude">Latitude(Inoperante para está versão)</label>
-                  <input id="latitude" type="text" class="validate" name="latitude" [readonly]="true" [(ngModel)]="enderecoPontPre.latitude">
+                <div class="two wide field">
+                  <label>Formato</label>
+                  <div class="grouped fields">
+                      <div class="field">
+                        <sui-radio-button name="latLongRadio" value="grau" [(ngModel)]="latLongRadio" (ngModelChange)="radioLatLong($event)">Grau</sui-radio-button>
+                      </div>
+                    <div class="field">
+                      <sui-radio-button name="latLongRadio" value="decimal" [(ngModel)]="latLongRadio" (ngModelChange)="radioLatLong($event)">Decimal</sui-radio-button>
+                    </div>
+                  </div>
                 </div>
+                <!-- Latitude e Longitude em decimal -->
+                <div class="ten wide field" *ngIf="!camposGraus">
+                  <div class="fields">
+                    <div class="eight wide field">
+                      <label for="latitude">Latitude</label>
+                      <input type="text" name="latitude" maxlength="10" [(ngModel)]="latLong.decimal.latitude" appLatitudeMask>
+                    </div>
+                    <div class="eight wide field">
+                      <label for="longitude">Longitude</label>
+                      <input type="text" name="longitude" maxlength="11" [(ngModel)]="latLong.decimal.longitude" appLongitudeMask>
+                    </div>
+                  </div>
+                </div>
+                <!-- Latitude e Longitude em graus -->
+                <div class="ten wide field" *ngIf="camposGraus">
+                  <div class="fields">
+                    <div class="eight wide field">
+                      <label for="latitude">Latitude</label>
+                      <div class="fields">
+                        <div class="four wide field">
+                          <sui-select class="selection" name="latTipo" [(ngModel)]="latLong.grau.latitude.latTipo" placeholder="...">
+                            <sui-select-option value="N">N</sui-select-option>
+                            <sui-select-option value="S">S</sui-select-option>
+                          </sui-select>
+                        </div>
+                        <div class="three wide field">
+                          <input type="text" name="latGrau" mask="99" [(ngModel)]="latLong.grau.latitude.latGrau">
+                          <b>Graus</b>
+                        </div>
+                        <b>º</b>
+                        <div class="three wide field">
+                          <input type="text" name="latMin" mask="99" [(ngModel)]="latLong.grau.latitude.latMin">
+                          <b>Minutos</b>
+                        </div>
+                        <b>'</b>
+                        <div class="five wide field">
+                          <input type="text" name="latSeg" mask="99.99" [dropSpecialCharacters]="false" [(ngModel)]="latLong.grau.latitude.latSeg">
+                          <b>Segundos</b>
+                        </div>
+                        <b>"</b>
+                      </div>
+                    </div>
 
-                <div class="five wide column">
-                  <label for="longitude">Longitude(Inoperante para está versão)</label>
-                  <input id="longitude" type="text" class="validate" name="longitude" [readonly]="true" [(ngModel)]="enderecoPontPre.longitude">
+                    <div class="eight wide field">
+                      <label for="latitude">Longitude</label>
+                      <div class="fields">
+                          <div class="four wide field">
+                            <sui-select class="selection" name="longTipo" [(ngModel)]="latLong.grau.longitude.longTipo" placeholder="...">
+                              <sui-select-option value="O">O</sui-select-option>
+                            </sui-select>
+                          </div>
+                          <div class="three wide field">
+                            <input type="text" name="longGrau" mask="99" [(ngModel)]="latLong.grau.longitude.longGrau">
+                            <b>Graus</b>
+                          </div>
+                          <b>º</b>
+                          <div class="three wide field">
+                            <input type="text" name="longMin" mask="99" [(ngModel)]="latLong.grau.longitude.longMin">
+                            <b>Minutos</b>
+                          </div>
+                          <b>'</b>
+                          <div class="five wide field">
+                            <input type="text" name="longSeg" mask="99.99" [dropSpecialCharacters]="false" [(ngModel)]="latLong.grau.longitude.longSeg">
+                            <b>Segundos</b>
+                          </div>
+                          <b>"</b>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
-              <div class="ui stackable two column grid">
-                <div class="column">
+              <div class="fields">
+                <div class="sixteen wide field">
                   <button class="ui red button" type="button" (click)="cancelAddEndereco()" [disabled]="enderecosAntigos?.length <= 0">Cancelar</button>
-                </div>
-                <div class="column">
                   <button class="ui button right floated" type="submit">Salvar</button>
                 </div>
               </div>
@@ -339,7 +402,8 @@
           </div>
 
           <!--Inicio do Modal seleção de varios GESAC -->
-          <sui-modal *ngIf="modalObsAcao && (enderecosAntigos.length === 0)" [isClosable]="false" [transition]="'scale'" [transitionDuration]="500" #modal>
+          <sui-modal *ngIf="modalObsAcao && (enderecosAntigos.length === 0)" [isClosable]="false" [transition]="'scale'" [transitionDuration]="500"
+            #modal>
             <div class="header">
 
               <div class="ui grid">

--- a/Front/src/app/ponto-presenca/ponto-presenca-add-edit/ponto-presenca-add-edit.component.scss
+++ b/Front/src/app/ponto-presenca/ponto-presenca-add-edit/ponto-presenca-add-edit.component.scss
@@ -28,7 +28,7 @@ $cor-azul-padrao: #002e9d;
 border: 1px solid red;
 }
 
-.ng-valid:not(form) {
-border: 1px solid green;
+sui-select.ui.selection.dropdown {
+  min-width: 2em;
 }
 

--- a/Front/src/app/ponto-presenca/ponto-presenca-add-edit/ponto-presenca-add-edit.component.ts
+++ b/Front/src/app/ponto-presenca/ponto-presenca-add-edit/ponto-presenca-add-edit.component.ts
@@ -28,8 +28,32 @@ export class PontoPresencaAddEditComponent implements OnInit {
   obsAcoesCad: Object;
   obsAcoes: Object;
   fecharmodal = true;
+  camposGraus = true;
   parametroIdentificador: any;
   modalObsAcao = false;
+  latLongRadio = 'grau';
+
+  latLong = {
+    decimal: {
+      latitude: '',
+      longitude: ''
+    },
+    grau: {
+      latitude: {
+        latTipo: '',
+        latGrau: null,
+        latMin: null,
+        latSeg: null
+      },
+      longitude: {
+        longTipo: '',
+        longGrau: null,
+        longMin: null,
+        longSeg: null
+      }
+    }
+  };
+
   /*
   *   Variaveis do de manipulacão das informacões de tipologia
   */
@@ -156,6 +180,90 @@ export class PontoPresencaAddEditComponent implements OnInit {
     this.pontoPresenca.cod_ibge = '';
   }
 
+  grauToDecimal() {
+    let lat = null;
+    let long = null;
+
+    const latGrau = Number(this.latLong.grau.latitude.latGrau);
+    const latMin = Number(this.latLong.grau.latitude.latMin);
+    const latSeg = Number(this.latLong.grau.latitude.latSeg);
+    const longGrau = Number(this.latLong.grau.longitude.longGrau);
+    const longMin = Number(this.latLong.grau.longitude.longMin);
+    const longSeg = Number(this.latLong.grau.longitude.longSeg);
+
+    // Latitude
+    if (!((latGrau === 0) && (latMin === 0) && (latSeg === 0))) {
+      lat = ( latGrau + ( (latMin / 60) + (latSeg / 3600) )).toFixed(6);
+      if ( this.latLong.grau.latitude.latTipo === 'S' ) {
+        this.latLong.decimal.latitude = `-${lat.toString()}`;
+      } else {
+        this.latLong.decimal.latitude = `+${lat.toString()}`;
+      }
+    } else {
+      this.latLong.decimal.latitude = '';
+    }
+
+    // Longitude
+    if (!((longGrau === 0) && (longMin === 0) && (longSeg === 0))) {
+      long = (longGrau + ( ( longMin / 60) + ( longSeg / 3600) )).toFixed(6);
+      this.latLong.decimal.longitude = `-${long.toString()}`;
+    } else {
+      this.latLong.decimal.longitude = '';
+    }
+  }
+
+  decimalToGrau(latitude, longitude) {
+    let latGrau = null;
+    let latMin = null;
+    let latSeg = null;
+    let latTipo = '';
+    let longGrau = null;
+    let longMin = null;
+    let longSeg = null;
+    const longTipo = 'O';
+    let latitudeDecimal = Number(latitude);
+    const longitudeDecimal = Number(longitude) * -1;
+
+    (latitudeDecimal < 0) ? (latTipo = 'S', latitudeDecimal = latitudeDecimal * -1) : latTipo = 'N';
+
+    if (latitude && !isNaN(latitude)) {
+      // Grau Latitude
+      latGrau = Math.trunc(latitudeDecimal);
+      // Minutos Latitude
+      latMin = Math.trunc((latitudeDecimal * 60) % 60);
+      // Segundos Latitude
+      latSeg = ((latitudeDecimal * 3600) % 60).toFixed(2);
+
+      this.latLong.grau.latitude.latTipo = latTipo;
+      this.latLong.grau.latitude.latGrau = latGrau;
+      this.latLong.grau.latitude.latMin = latMin;
+      this.latLong.grau.latitude.latSeg = latSeg;
+    } else {
+      this.latLong.grau.latitude.latTipo = '';
+      this.latLong.grau.latitude.latGrau = null;
+      this.latLong.grau.latitude.latMin = null;
+      this.latLong.grau.latitude.latSeg = null;
+    }
+    if (longitude && !isNaN(longitude)) {
+      // Grau Longitude
+      longGrau = Math.trunc(longitudeDecimal);
+      // Minutos Longitude
+      longMin = Math.trunc((longitudeDecimal * 60) % 60);
+      // Segundos Longitude
+      longSeg = ((longitudeDecimal * 3600) % 60).toFixed(2);
+
+      this.latLong.grau.longitude.longTipo = longTipo;
+      this.latLong.grau.longitude.longGrau = longGrau;
+      this.latLong.grau.longitude.longMin = longMin;
+      this.latLong.grau.longitude.longSeg = longSeg;
+    } else {
+      this.latLong.grau.longitude.longTipo = '';
+      this.latLong.grau.longitude.longGrau = null;
+      this.latLong.grau.longitude.longMin = null;
+      this.latLong.grau.longitude.longSeg = null;
+    }
+  }
+
   /*
  * Método para o contrato do banco
  */
@@ -242,7 +350,6 @@ export class PontoPresencaAddEditComponent implements OnInit {
       .getEnderecoDetalhe(this.params.id || this.codGesac)
       .subscribe(dados => {
         this.enderecosAntigos = dados;
-        console.log(dados);
         if (this.enderecosAntigos.length === 0) {
           this.novoEndereco = true;
         } else {
@@ -350,7 +457,6 @@ export class PontoPresencaAddEditComponent implements OnInit {
     if (this.enderecosAntigos.lenght !== 0) {
       for (let i = 0; i < this.enderecosAntigos.length; i++) {
         if (!this.enderecosAntigos[i].data_final) {
-
           this.enderecoPontPre = {
             cod_endereco: this.enderecosAntigos[i].cod_endereco,
             endereco: this.enderecosAntigos[i].endereco,
@@ -359,9 +465,14 @@ export class PontoPresencaAddEditComponent implements OnInit {
             complemento: this.enderecosAntigos[i].complemento,
             cep: this.enderecosAntigos[i].cep,
             area: this.enderecosAntigos[i].area,
-            latitude: null,
-            longitude: null
+            latitude: this.enderecosAntigos[i].latitude,
+            longitude: this.enderecosAntigos[i].longitude
           };
+          this.latLongRadio = 'grau';
+          this.camposGraus = true;
+          this.latLong.decimal.latitude = this.enderecosAntigos[i].latitude;
+          this.latLong.decimal.longitude = this.enderecosAntigos[i].longitude;
+          this.decimalToGrau(this.enderecosAntigos[i].latitude, this.enderecosAntigos[i].longitude);
         }
       }
     } else {
@@ -378,22 +489,57 @@ export class PontoPresencaAddEditComponent implements OnInit {
       };
     }
   }
+
+  longIsValid (lat) {
+    if (lat) {
+      lat = Number(lat);
+      return ((lat > -75) && (lat < -32));
+    } else {
+      return true;
+    }
+  }
+
+  latIsValid (long) {
+    if (long) {
+      long = Number(long);
+      return ((long < 6) && (long > -34));
+    } else {
+      return true;
+    }
+  }
   /*
 * Métodos para salvar/editar o Endereco no banco, caso seja passado um id na rota ocorrerá um put, caso contrario será um post
 */
   salvarEndereco(form) {
     // mostrar botão 'adicionar endereco' (quando clicado limpar os campos do endereco e setar variavel da clausula if)
     if (form.status !== 'INVALID') {
+      if (form.value.latLongRadio === 'grau') {
+        this.grauToDecimal();
+      }
+      const validLat = this.latIsValid(this.latLong.decimal.latitude);
+      const validLong = this.longIsValid(this.latLong.decimal.longitude);
+      if (validLat && validLong) {
+        const formEnvio: any = {};
+      if (form.value.latLongRadio === 'grau') {
+        this.grauToDecimal();
+      }
       this.enderecosAntigos.length !== 0
         ? (form.value.cod_endereco = this.enderecoPontPre.cod_endereco + 1)
         : (form.value.cod_endereco = 1);
 
-      form.value.cod_gesac = this.codGesac;
-      form.value.latitude = null;
-      form.value.longitude = null;
-      form.value.data_inicio = this.apiServicesData.formatData(new Date());
-      this.pontoPresencaService.postEndereco(form.value).subscribe(dados => {
+      formEnvio.cod_endereco = form.value.cod_endereco;
+      formEnvio.cod_gesac = this.codGesac;
+      formEnvio.endereco = form.value.endereco;
+      formEnvio.numero = form.value.numero;
+      formEnvio.bairro = form.value.bairro;
+      formEnvio.cep = form.value.cep;
+      formEnvio.complemento = form.value.complemento;
+      formEnvio.area = form.value.area;
+      formEnvio.latitude = this.latLong.decimal.latitude || null;
+      formEnvio.longitude = this.latLong.decimal.longitude || null;
+      formEnvio.data_inicio = this.apiServicesData.formatData(new Date());
 
+      this.pontoPresencaService.postEndereco(formEnvio).subscribe(dados => {
         this.cancelAddEndereco();
         this.getEnderecosAntigos();
         this.novoEndereco = !this.novoEndereco;
@@ -407,6 +553,17 @@ export class PontoPresencaAddEditComponent implements OnInit {
           3000
         );
       });
+      } else {
+        if (!validLat || !validLong) {
+          if (form.value.latLongRadio === 'grau' ) {
+            this.apiServicesMsg.setMsg('warning', `A latitude deve estar entre N 6º 00' 00" e S 34º 00' 00"
+                                                   e a longitude deve estar entre O 32º 00' 00" e O 75º 00' 00".`, 10000);
+          } else {
+            this.apiServicesMsg.setMsg('warning', `A latitude deve estar entre +6.000000 e -34.000000
+                                                   e a longitude deve estar entre -75.000000 e -32.000000.`, 10000);
+          }
+        }
+      }
     } else {
       this.apiServicesMsg.setMsg(
         'error',
@@ -625,6 +782,16 @@ closeModal() {
       this.router.navigate(['/pontPre']);
     } else if (this.params.detalheappeditPP) {
       this.router.navigate(['/pontPre', this.params.detalheappeditPP, 'detalhe']);
+    }
+  }
+
+  radioLatLong(value) {
+    if (value === 'decimal') {
+      this.camposGraus = false;
+      this.grauToDecimal();
+    } else {
+      this.camposGraus = true;
+      this.decimalToGrau(this.latLong.decimal.latitude, this.latLong.decimal.longitude);
     }
   }
 


### PR DESCRIPTION
Foram adicionadas as máscaras para latitude e longitude
Para utilização das máscaras basta implementar as diretivas **appLatitudeMask** ou **appLongitudeMask** para o tipo de máscara que desejar.
Os formatos da máscara para latitude são: 
`+9.999999`, `-9.999999`, `+99.999999` ou `-99.999999`, onde **9** são números de **0** a **9**.
Os formatos da máscara para longitude são: 
`-9.999999`, `-99.999999` ou `-999.999999`, onde **9** são números de **0** a **9**.